### PR TITLE
block device handling: Dont match on the root bus to support cloud hypervisor

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -1,5 +1,6 @@
 name: CI | Build kata-static tarball for amd64
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       stage:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -1,5 +1,6 @@
 name: CI | Build kata-static tarball for arm64
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       stage:

--- a/.github/workflows/release-runloop.yaml
+++ b/.github/workflows/release-runloop.yaml
@@ -1,0 +1,24 @@
+name: Build amd64 and arm64 Static Binaries
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build-static-tarball-amd64:
+    uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
+    with:
+      push-to-registry: "no"
+      stage: "test"
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ""
+      KBUILD_SIGN_PIN: ""
+
+  build-static-tarball-arm64:
+    uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
+    with:
+      push-to-registry: "no"
+      stage: "test"
+    secrets:
+      QUAY_DEPLOYER_PASSWORD: ""

--- a/.github/workflows/release-runloop.yaml
+++ b/.github/workflows/release-runloop.yaml
@@ -5,6 +5,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
+
 jobs:
   build-static-tarball-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 name: Release Kata Containers
 on:
-  workflow_dispatch
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/src/agent/src/device/block_device_handler.rs
+++ b/src/agent/src/device/block_device_handler.rs
@@ -163,8 +163,7 @@ pub struct VirtioBlkPciMatcher {
 
 impl VirtioBlkPciMatcher {
     pub fn new(relpath: &str) -> VirtioBlkPciMatcher {
-        let root_bus = create_pci_root_bus_path();
-        let re = format!(r"^{}{}/virtio[0-9]+/block/", root_bus, relpath);
+        let re = format!(r"{}/virtio[0-9]+/block/", relpath);
 
         VirtioBlkPciMatcher {
             rex: Regex::new(&re).expect("BUG: failed to compile VirtioBlkPciMatcher regex"),


### PR DESCRIPTION
Cloud hypervisor fails a huge percentage of the time (but not always!) due to 
```
Error: failed to create containerd task: failed to create shim task: Timeout after 3s waiting for uevent VirtioBlkPciMatcher { rex: Regex("^/devices/platform/4010000000.pcie/pci0000:00/0000:00:05.0/virtio[0-9]+/block/") }...
```

The root_bus seems to differ between qemu and cloud-hypervisor, so remove it from the regex.